### PR TITLE
More frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ writer.setFrame('TIT2', 'Home')
       .setFrame('TRCK', '6/8')
       .setFrame('TPOS', '1/2')
       .setFrame('TCON', ['Soundtrack'])
+      .setFrame('TBPM', '128')
+      .setFrame('TKEY', 'Fbm')
       .setFrame('USLT', 'This is unsychronised lyrics')
       .setFrame('TXXX', {
           description: 'Release Info',
@@ -170,6 +172,8 @@ writer.setFrame('TIT2', 'Home')
       .setFrame('TRCK', '6/8')
       .setFrame('TPOS', '1/2')
       .setFrame('TCON', ['Soundtrack'])
+      .setFrame('TBPM', '128')
+      .setFrame('TKEY', 'Fbm')
       .setFrame('USLT', 'This is unsychronised lyrics')
       .setFrame('TXXX', {
           description: 'Release Info',
@@ -209,8 +213,17 @@ Currently you can set next frames:
 - TIT2 (song title)
 - TALB (album title)
 - TPE2 (album artist)
+- TPE3 (conductor)
+- TPE4 (people behind a remix and similar interpretations)
 - TRCK (song number in album): '5' or '5/10'
 - TPOS (album disc number): '1' or '1/3'
+- TSOA (album name for sorting)
+- TSOP (performer/artist for sorting)
+- TSOT (title for sorting)
+- TBPM (beats per minute)
+- TKEY (initial musical key): like 'C', 'B#', 'Fbm' or 'o' (off key)
+- TMOO (description of mood)
+- TMED (media song originated from): like 'DIG', 'CD', 'TT/33' etc
 - USLT (unsychronised lyrics)
 - TPUB (label name)
 

--- a/src/browser-id3-writer.js
+++ b/src/browser-id3-writer.js
@@ -167,6 +167,18 @@ class Writer {
                 this._setStringFrame(frameName, genresStr);
                 break;
             }
+            case 'TKEY': // musical key in which the sound starts
+            {
+                if(!/^([A-G][#b]?m?|o)$/.test(frameValue)) {
+                    //specs: The ground keys are represented with "A","B","C","D","E",
+                    //"F" and "G" and halfkeys represented with "b" and "#". Minor is
+                    //represented as "m", e.g. "Dbm". Off key is represented with an
+                    //"o" only.
+                    throw new Error(`${frameName} frame value should be like Dbm, C#, B or o`);
+                }
+                this._setStringFrame(frameName, frameValue);
+                break;
+            }
             case 'TIT2': // song title
             case 'TALB': // album title
             case 'TPE2': // album artist // spec doesn't say anything about separator, so it is a string, not array
@@ -272,6 +284,7 @@ class Writer {
                 case 'TPOS':
                 case 'TPUB':
                 case 'TBPM':
+                case 'TKEY':
                 {
                     writeBytes = [1].concat(BOM); // encoding, BOM
                     bufferWriter.set(writeBytes, offset);

--- a/src/browser-id3-writer.js
+++ b/src/browser-id3-writer.js
@@ -188,6 +188,7 @@ class Writer {
             case 'TPOS': // album disc number: 1 or 1/3
             case 'TPUB': // label name
             case 'TBPM': // number of beats per minute //specs say it is an int and represented as a numerical string
+            case 'TMED': // media the sound originated from (eg. DIG, CD, TT/33, VID/PAL, RAD/FM, etc)
             {
                 this._setStringFrame(frameName, frameValue);
                 break;
@@ -289,6 +290,7 @@ class Writer {
                 case 'TPUB':
                 case 'TBPM':
                 case 'TKEY':
+                case 'TMED':
                 {
                     writeBytes = [1].concat(BOM); // encoding, BOM
                     bufferWriter.set(writeBytes, offset);

--- a/src/browser-id3-writer.js
+++ b/src/browser-id3-writer.js
@@ -182,6 +182,8 @@ class Writer {
             case 'TIT2': // song title
             case 'TALB': // album title
             case 'TPE2': // album artist // spec doesn't say anything about separator, so it is a string, not array
+            case 'TPE3': // name of the conductor
+            case 'TPE4': // people behind a remix and similar interpretations
             case 'TRCK': // song number in album: 5 or 5/10
             case 'TPOS': // album disc number: 1 or 1/3
             case 'TPUB': // label name
@@ -280,6 +282,8 @@ class Writer {
                 case 'TIT2':
                 case 'TALB':
                 case 'TPE2':
+                case 'TPE3':
+                case 'TPE4':
                 case 'TRCK':
                 case 'TPOS':
                 case 'TPUB':

--- a/src/browser-id3-writer.js
+++ b/src/browser-id3-writer.js
@@ -173,6 +173,7 @@ class Writer {
             case 'TRCK': // song number in album: 5 or 5/10
             case 'TPOS': // album disc number: 1 or 1/3
             case 'TPUB': // label name
+            case 'TBPM': // number of beats per minute //specs say it is an int and represented as a numerical string
             {
                 this._setStringFrame(frameName, frameValue);
                 break;
@@ -270,6 +271,7 @@ class Writer {
                 case 'TRCK':
                 case 'TPOS':
                 case 'TPUB':
+                case 'TBPM':
                 {
                     writeBytes = [1].concat(BOM); // encoding, BOM
                     bufferWriter.set(writeBytes, offset);

--- a/src/browser-id3-writer.js
+++ b/src/browser-id3-writer.js
@@ -190,6 +190,9 @@ class Writer {
             case 'TBPM': // number of beats per minute //specs say it is an int and represented as a numerical string
             case 'TMED': // media the sound originated from (e.g. DIG, CD, TT/33, VID/PAL, RAD/FM, etc)
             case 'TMOO': // reflect the mood of the audio with a few keywords, e.g. "Romantic" or "Sad".
+            case 'TSOA': // string which should be used instead of the album name (TALB) for sorting purposes
+            case 'TSOP': // string which should be used instead of the performer (TPE2) for sorting purposes
+            case 'TSOT': // string which should be used instead of the title (TIT2) for sorting purposes
             {
                 this._setStringFrame(frameName, frameValue);
                 break;
@@ -293,6 +296,9 @@ class Writer {
                 case 'TKEY':
                 case 'TMED':
                 case 'TMOO':
+                case 'TSOA':
+                case 'TSOP':
+                case 'TSOT':
                 {
                     writeBytes = [1].concat(BOM); // encoding, BOM
                     bufferWriter.set(writeBytes, offset);

--- a/src/browser-id3-writer.js
+++ b/src/browser-id3-writer.js
@@ -188,7 +188,8 @@ class Writer {
             case 'TPOS': // album disc number: 1 or 1/3
             case 'TPUB': // label name
             case 'TBPM': // number of beats per minute //specs say it is an int and represented as a numerical string
-            case 'TMED': // media the sound originated from (eg. DIG, CD, TT/33, VID/PAL, RAD/FM, etc)
+            case 'TMED': // media the sound originated from (e.g. DIG, CD, TT/33, VID/PAL, RAD/FM, etc)
+            case 'TMOO': // reflect the mood of the audio with a few keywords, e.g. "Romantic" or "Sad".
             {
                 this._setStringFrame(frameName, frameValue);
                 break;
@@ -291,6 +292,7 @@ class Writer {
                 case 'TBPM':
                 case 'TKEY':
                 case 'TMED':
+                case 'TMOO':
                 {
                     writeBytes = [1].concat(BOM); // encoding, BOM
                     bufferWriter.set(writeBytes, offset);

--- a/test/common.js
+++ b/test/common.js
@@ -174,6 +174,14 @@ const tests = [{
                 27, 4, 56, 4, 64, 4, 56, 4, 58, 4, 48, 4 // Лирика
             ]));
         }
+    }, {
+        describe: 'should throw an exception with wrong value for TKEY frame',
+        test: (ID3Writer, expect) => {
+            const writer = new ID3Writer(files.mp3);
+            expect(() => {
+                writer.setFrame('TKEY', 'C minor');
+            }).to.throw(Error, 'TKEY frame value should be like Dbm, C#, B or o');
+        }
     }]
 }, {
     describe: 'APIC',

--- a/test/node.js
+++ b/test/node.js
@@ -35,13 +35,16 @@ describe('node usage', () => {
             .setFrame('TCON', ['Soundtrack'])
             .setFrame('TMED', 'TT/45')
             .setFrame('TMOO', 'Happy')
+            .setFrame('TSOA', 'Friday Night Lights')
+            .setFrame('TSOP', 'Eminem')
+            .setFrame('TSOT', 'Home')
             .setFrame('USLT', 'This is unsychronised lyrics')
             .setFrame('APIC', coverBuffer);
         writer.addTag();
-        expect(writer.arrayBuffer.byteLength).to.be.equal(668842);
+        expect(writer.arrayBuffer.byteLength).to.be.equal(668939);
 
         const taggedSongBuffer = new Buffer(writer.arrayBuffer);
-        expect(taggedSongBuffer.byteLength).to.be.equal(668842);
+        expect(taggedSongBuffer.byteLength).to.be.equal(668939);
         fs.writeFileSync(path.join(assetFolder, 'song_with_tags.mp3'), taggedSongBuffer);
     });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -28,14 +28,15 @@ describe('node usage', () => {
             .setFrame('TYER', 2004)
             .setFrame('TRCK', '6/8')
             .setFrame('TPOS', '1/2')
+            .setFrame('TBPM', '128')
             .setFrame('TCON', ['Soundtrack'])
             .setFrame('USLT', 'This is unsychronised lyrics')
             .setFrame('APIC', coverBuffer);
         writer.addTag();
-        expect(writer.arrayBuffer.byteLength).to.be.equal(668692);
+        expect(writer.arrayBuffer.byteLength).to.be.equal(668711);
 
         const taggedSongBuffer = new Buffer(writer.arrayBuffer);
-        expect(taggedSongBuffer.byteLength).to.be.equal(668692);
+        expect(taggedSongBuffer.byteLength).to.be.equal(668711);
         fs.writeFileSync(path.join(assetFolder, 'song_with_tags.mp3'), taggedSongBuffer);
     });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -33,13 +33,14 @@ describe('node usage', () => {
             .setFrame('TBPM', '128')
             .setFrame('TKEY', 'Fbm')
             .setFrame('TCON', ['Soundtrack'])
+            .setFrame('TMED', 'TT/45')
             .setFrame('USLT', 'This is unsychronised lyrics')
             .setFrame('APIC', coverBuffer);
         writer.addTag();
-        expect(writer.arrayBuffer.byteLength).to.be.equal(668796);
+        expect(writer.arrayBuffer.byteLength).to.be.equal(668819);
 
         const taggedSongBuffer = new Buffer(writer.arrayBuffer);
-        expect(taggedSongBuffer.byteLength).to.be.equal(668796);
+        expect(taggedSongBuffer.byteLength).to.be.equal(668819);
         fs.writeFileSync(path.join(assetFolder, 'song_with_tags.mp3'), taggedSongBuffer);
     });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -24,6 +24,8 @@ describe('node usage', () => {
         writer.setFrame('TIT2', 'Home')
             .setFrame('TPE1', ['Eminem', '50 Cent'])
             .setFrame('TPE2', 'Eminem')
+            .setFrame('TPE3', 'FooComposer')
+            .setFrame('TPE4', 'Daft Punk')
             .setFrame('TALB', 'Friday Night Lights')
             .setFrame('TYER', 2004)
             .setFrame('TRCK', '6/8')
@@ -34,10 +36,10 @@ describe('node usage', () => {
             .setFrame('USLT', 'This is unsychronised lyrics')
             .setFrame('APIC', coverBuffer);
         writer.addTag();
-        expect(writer.arrayBuffer.byteLength).to.be.equal(668730);
+        expect(writer.arrayBuffer.byteLength).to.be.equal(668796);
 
         const taggedSongBuffer = new Buffer(writer.arrayBuffer);
-        expect(taggedSongBuffer.byteLength).to.be.equal(668730);
+        expect(taggedSongBuffer.byteLength).to.be.equal(668796);
         fs.writeFileSync(path.join(assetFolder, 'song_with_tags.mp3'), taggedSongBuffer);
     });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -34,13 +34,14 @@ describe('node usage', () => {
             .setFrame('TKEY', 'Fbm')
             .setFrame('TCON', ['Soundtrack'])
             .setFrame('TMED', 'TT/45')
+            .setFrame('TMOO', 'Happy')
             .setFrame('USLT', 'This is unsychronised lyrics')
             .setFrame('APIC', coverBuffer);
         writer.addTag();
-        expect(writer.arrayBuffer.byteLength).to.be.equal(668819);
+        expect(writer.arrayBuffer.byteLength).to.be.equal(668842);
 
         const taggedSongBuffer = new Buffer(writer.arrayBuffer);
-        expect(taggedSongBuffer.byteLength).to.be.equal(668819);
+        expect(taggedSongBuffer.byteLength).to.be.equal(668842);
         fs.writeFileSync(path.join(assetFolder, 'song_with_tags.mp3'), taggedSongBuffer);
     });
 });

--- a/test/node.js
+++ b/test/node.js
@@ -29,14 +29,15 @@ describe('node usage', () => {
             .setFrame('TRCK', '6/8')
             .setFrame('TPOS', '1/2')
             .setFrame('TBPM', '128')
+            .setFrame('TKEY', 'Fbm')
             .setFrame('TCON', ['Soundtrack'])
             .setFrame('USLT', 'This is unsychronised lyrics')
             .setFrame('APIC', coverBuffer);
         writer.addTag();
-        expect(writer.arrayBuffer.byteLength).to.be.equal(668711);
+        expect(writer.arrayBuffer.byteLength).to.be.equal(668730);
 
         const taggedSongBuffer = new Buffer(writer.arrayBuffer);
-        expect(taggedSongBuffer.byteLength).to.be.equal(668711);
+        expect(taggedSongBuffer.byteLength).to.be.equal(668730);
         fs.writeFileSync(path.join(assetFolder, 'song_with_tags.mp3'), taggedSongBuffer);
     });
 });


### PR DESCRIPTION
Hi Artyom,
your library is really handy for one of my recent projects!

For said project I had to set some frames currently not implemented in this library, so I added them.
Most of them (`TBPM`, `TPE3`, `TPE4`, `TSOA`, `TSOP`, `TSOT`, `TMED`, `TMOO`) are simple string frames.
For `TKEY `I added a check with regex, so only valid formats are allowed.
To set the frame for user text information (`TXXX`, see http://id3.org/id3v2.3.0#line-496 for more info) the `setFrame` method has to be called with both frame name and an object containing a description and the actual value.

Some test cases for the new tags were also implemented and the readme updated accordingly.

I tried to keep the code style of the rest of the project, feel free to suggest improvements.