### PR TITLE
Allow users to switch charset encodings of APIC frame, fixes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ writer.revokeURL(); // if you have access to writer
 
 ### Node.js
 
-Simple example with blocking IO: 
+Simple example with blocking IO:
 
 ```js
 const ID3Writer = require('browser-id3-writer');
@@ -286,9 +286,14 @@ writer.setFrame('TXXX', {
 writer.setFrame('APIC', {
     type: 3,
     data: coverArrayBuffer,
-    description: 'description here'
+    description: 'description here',
+    useUnicodeEncoding: false
 });
 ```
+
+`useUnicodeEncoding` should only be `true` when description contains non-Western characters.
+When it's set to `true` some program might not be able to read the picture correctly.
+See [#42](https://github.com/egoroof/browser-id3-writer/issues/42).
 
 ## APIC picture types
 

--- a/src/sizes.js
+++ b/src/sizes.js
@@ -38,23 +38,22 @@ export function getLyricsFrameSize(descriptionSize, lyricsSize) {
         lyricsUtf16Size;
 }
 
-export function getPictureFrameSize(pictureSize, mimeTypeSize, descriptionSize) {
+export function getPictureFrameSize(pictureSize, mimeTypeSize, descriptionSize, useUnicodeEncoding) {
     const headerSize = 10;
     const encodingSize = 1;
     const separatorSize = 1;
     const pictureTypeSize = 1;
     const bomSize = 2;
-    const descriptionUtf16Size = descriptionSize * 2;
+    const encodedDescriptionSize = useUnicodeEncoding ?
+        bomSize + (descriptionSize + separatorSize) * 2 :
+        descriptionSize + separatorSize;
 
     return headerSize +
         encodingSize +
         mimeTypeSize +
         separatorSize +
         pictureTypeSize +
-        bomSize +
-        descriptionUtf16Size +
-        separatorSize +
-        separatorSize +
+        encodedDescriptionSize +
         pictureSize;
 }
 

--- a/test/node.js
+++ b/test/node.js
@@ -59,7 +59,8 @@ describe('node usage', () => {
             .setFrame('APIC', {
                 type: 3,
                 data: coverBuffer,
-                description: 'Super picture'
+                description: 'Super picture',
+                useUnicodeEncoding: true
             });
         writer.addTag();
 


### PR DESCRIPTION
There are some quirks with APIC frame parsing on macOS iTunes and Finder. When the description is encoded in Unicode and is either an empty string or with an non-Western character as the last character, iTunes will fail to parse the picture from the frame.

This fix workaround it by always use Western encoding when the description is empty, and only opt to Unicode encoding when the caller explicitly choose to with `useUnicodeEncoding: true`. README.md is updated accordingly with a warning.