### PR TITLE
Support More Valid ID3 Frames: TCOP, TSRC and TDAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ Have not found needed frame? Open a new issue and we'll discuss it.
 - TPUB (label name)
 - TKEY (initial key)
 - TMED (media type)
+- TSRC (isrc - international standard recording code)
+- TCOP (copyright message)
 - WCOM (commercial information)
 - WCOP (copyright/Legal information)
 - WOAF (official audio file webpage)
@@ -232,6 +234,7 @@ Have not found needed frame? Open a new issue and we'll discuss it.
 **integer**
 
 - TLEN (song duration in milliseconds)
+- TDAT (album release date expressed as DDMM)
 - TYER (album release year)
 - TBPM (beats per minute)
 

--- a/src/ID3Writer.js
+++ b/src/ID3Writer.js
@@ -141,6 +141,7 @@ export default class ID3Writer {
             }
             case 'TBPM': // beats per minute
             case 'TLEN': // song duration
+            case 'TDAT': // album release date expressed as DDMM
             case 'TYER': { // album release year
                 this._setIntegerFrame(frameName, frameValue);
                 break;
@@ -321,6 +322,7 @@ export default class ID3Writer {
                 }
                 case 'TBPM':
                 case 'TLEN':
+                case 'TDAT':
                 case 'TYER': {
                     offset++; // encoding
 

--- a/src/ID3Writer.js
+++ b/src/ID3Writer.js
@@ -133,7 +133,9 @@ export default class ID3Writer {
             case 'TRCK': // song number in album: 5 or 5/10
             case 'TPOS': // album disc number: 1 or 1/3
             case 'TMED': // media type
-            case 'TPUB': { // label name
+            case 'TPUB': // label name
+            case 'TCOP': // copyright
+            case 'TSRC': { // isrc
                 this._setStringFrame(frameName, frameValue);
                 break;
             }
@@ -281,7 +283,9 @@ export default class ID3Writer {
                 case 'TPOS':
                 case 'TKEY':
                 case 'TMED':
-                case 'TPUB': {
+                case 'TPUB':
+                case 'TCOP':
+                case 'TSRC': {
                     writeBytes = [1].concat(BOM); // encoding, BOM
                     bufferWriter.set(writeBytes, offset);
                     offset += writeBytes.length;


### PR DESCRIPTION
## Intent

Adds support for additional valid ID3 frames: TCOP, TSRC and TDAT.  They are all specified in the [Informal Standard Spec](http://id3.org/d3v2.3.0)

I'm sure there's others, but these were common missing frames I encountered personally in my projects. 