### PR TITLE
Add language support for COMM and USLT

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ const id3Buffer = Buffer.from(writer.arrayBuffer);
 
 ```js
 writer.setFrame('COMM', {
-    language: 'eng',
     description: 'description here',
     text: 'text here'
 });
@@ -256,7 +255,6 @@ writer.setFrame('COMM', {
 
 ```js
 writer.setFrame('USLT', {
-    language: 'eng',
     description: 'description here',
     lyrics: 'lyrics here'
 });

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ const id3Buffer = Buffer.from(writer.arrayBuffer);
 
 ```js
 writer.setFrame('COMM', {
+    language: 'eng',
     description: 'description here',
     text: 'text here'
 });
@@ -255,6 +256,7 @@ writer.setFrame('COMM', {
 
 ```js
 writer.setFrame('USLT', {
+    language: 'eng',
     description: 'description here',
     lyrics: 'lyrics here'
 });

--- a/src/ID3Writer.js
+++ b/src/ID3Writer.js
@@ -176,10 +176,11 @@ export default class ID3Writer {
                 break;
             }
             case 'USLT': { // unsychronised lyrics
-                if (typeof frameValue !== 'object' || !('language' in frameValue) || !('description' in frameValue) || !('lyrics' in frameValue)) {
-                    throw new Error('USLT frame value should be an object with keys language, description, and lyrics');
+                frameValue.language = frameValue.language || 'eng';
+                if (typeof frameValue !== 'object' || !('description' in frameValue) || !('lyrics' in frameValue)) {
+                    throw new Error('USLT frame value should be an object with keys description and lyrics');
                 }
-                if (frameValue.language.length !== 3) {
+                if (frameValue.language && !frameValue.language.match(/[a-z]{3}/i)) {
                     throw new Error('Language must be coded following the ISO 639-2 standards');
                 }
                 this._setLyricsFrame(frameValue.language, frameValue.description, frameValue.lyrics);
@@ -214,10 +215,11 @@ export default class ID3Writer {
                 break;
             }
             case 'COMM': { // Comments
+                frameValue.language = frameValue.language || 'eng';
                 if (typeof frameValue !== 'object' || !('language' in frameValue) || !('description' in frameValue) || !('text' in frameValue)) {
                     throw new Error('COMM frame value should be an object with keys description and text');
                 }
-                if (frameValue.language.length !== 3) {
+                if (frameValue.language && !frameValue.language.match(/[a-z]{3}/i)) {
                     throw new Error('Language must be coded following the ISO 639-2 standards');
                 }
                 this._setCommentFrame(frameValue.language, frameValue.description, frameValue.text);

--- a/src/ID3Writer.js
+++ b/src/ID3Writer.js
@@ -56,36 +56,28 @@ export default class ID3Writer {
     }
 
     _setLyricsFrame(language, description, lyrics) {
-        const languageBuffer = [];
+        const languageCode = language.split('').map(c => c.charCodeAt(0));
         const descriptionString = description.toString();
         const lyricsString = lyrics.toString();
-
-        for (let i = 0; i < language.length; i++) {
-          languageBuffer[i] = language.charCodeAt(i);
-        }
 
         this.frames.push({
             name: 'USLT',
             value: lyricsString,
-            language: languageBuffer,
+            language: languageCode,
             description: descriptionString,
             size: getLyricsFrameSize(descriptionString.length, lyricsString.length),
         });
     }
 
     _setCommentFrame(language, description, text) {
-        const languageBuffer = [];
+        const languageCode = language.split('').map(c => c.charCodeAt(0));
         const descriptionString = description.toString();
         const textString = text.toString();
-
-        for (let i = 0; i < language.length; i++) {
-          languageBuffer[i] = language.charCodeAt(i);
-        }
 
         this.frames.push({
             name: 'COMM',
             value: textString,
-            language: languageBuffer,
+            language: languageCode,
             description: descriptionString,
             size: getCommentFrameSize(descriptionString.length, textString.length),
         });

--- a/test/object/COMM.js
+++ b/test/object/COMM.js
@@ -13,7 +13,6 @@ describe('COMM', () => {
         const writer = new ID3Writer(emptyBuffer);
         writer.padding = 0;
         writer.setFrame('COMM', {
-            language: 'eng',
             description: 'advert',
             text: 'free hugs',
         });

--- a/test/object/COMM.js
+++ b/test/object/COMM.js
@@ -13,6 +13,7 @@ describe('COMM', () => {
         const writer = new ID3Writer(emptyBuffer);
         writer.padding = 0;
         writer.setFrame('COMM', {
+            language: 'eng',
             description: 'advert',
             text: 'free hugs',
         });
@@ -28,6 +29,29 @@ describe('COMM', () => {
             97, 0, 100, 0, 118, 0, 101, 0, 114, 0, 116, 0, // 'advert'
             0, 0, 0xff, 0xfe, // separator, BOM
             102, 0, 114, 0, 101, 0, 101, 0, 32, 0, 104, 0, 117, 0, 103, 0, 115, 0, // 'free hugs'
+        ]);
+        assert.deepStrictEqual(actual, expected);
+    });
+    it('Change language', () => {
+        const writer = new ID3Writer(emptyBuffer);
+        writer.padding = 0;
+        writer.setFrame('COMM', {
+            language: 'jpn',
+            description: 'この世界',
+            text: '俺の名前',
+        });
+        writer.addTag();
+        const actual = new Uint8Array(writer.arrayBuffer);
+        const expected = new Uint8Array([
+          ...id3Header,
+          0, 0, 0, 36, // tag size without header
+          67, 79, 77, 77, // 'COMM'
+          0, 0, 0, 26, // size without header
+          0, 0, // flags
+          1, 106, 112, 110, 0xff, 0xfe, // encoding, language, BOM
+          83, 48, 110, 48, 22, 78, 76, 117, // 'この世界'
+          0, 0, 0xff, 0xfe, // separator, BOM
+          250, 79, 110, 48, 13, 84, 77, 82, // '俺の名前'
         ]);
         assert.deepStrictEqual(actual, expected);
     });

--- a/test/object/USLT.js
+++ b/test/object/USLT.js
@@ -13,7 +13,6 @@ describe('USLT', () => {
         const writer = new ID3Writer(emptyBuffer);
         writer.padding = 0;
         writer.setFrame('USLT', {
-            language: 'eng',
             description: 'Ярл',
             lyrics: 'Лирика',
         });

--- a/test/object/USLT.js
+++ b/test/object/USLT.js
@@ -13,6 +13,7 @@ describe('USLT', () => {
         const writer = new ID3Writer(emptyBuffer);
         writer.padding = 0;
         writer.setFrame('USLT', {
+            language: 'eng',
             description: 'Ярл',
             lyrics: 'Лирика',
         });
@@ -26,6 +27,31 @@ describe('USLT', () => {
             0, 0, // flags
             1, // encoding
             101, 110, 103, // language
+            0xff, 0xfe, // BOM
+            47, 4, 64, 4, 59, 4, // 'Ярл'
+            0, 0, 0xff, 0xfe, // separator, BOM
+            27, 4, 56, 4, 64, 4, 56, 4, 58, 4, 48, 4, // 'Лирика'
+        ]);
+        assert.deepStrictEqual(actual, expected);
+    });
+    it('USLT', () => {
+        const writer = new ID3Writer(emptyBuffer);
+        writer.padding = 0;
+        writer.setFrame('USLT', {
+            language: 'rus',
+            description: 'Ярл',
+            lyrics: 'Лирика',
+        });
+        writer.addTag();
+        const actual = new Uint8Array(writer.arrayBuffer);
+        const expected = new Uint8Array([
+            ...id3Header,
+            0, 0, 0, 38, // tag size without header
+            85, 83, 76, 84, // 'USLT'
+            0, 0, 0, 28, // size without header
+            0, 0, // flags
+            1, // encoding
+            114, 117, 115, // language
             0xff, 0xfe, // BOM
             47, 4, 64, 4, 59, 4, // 'Ярл'
             0, 0, 0xff, 0xfe, // separator, BOM


### PR DESCRIPTION
Request: #62 
I also modified the test scripts to match the new feature.

Example usage:
```javascript
writer.setFrame('USLT', {
  language: 'jpn',
  description: '例えば',
  lyrics: 'サマータイム'
})
```

### Note
 * Language defaults to `eng`
 * Language code must follow the [ISO 639-2](https://www.loc.gov/standards/iso639-2/php/code_list.php) standards (3-letter language code)
