### PR TITLE
Fix TDAT size

### DIFF
--- a/src/ID3Writer.mjs
+++ b/src/ID3Writer.mjs
@@ -19,7 +19,7 @@ import {
 export default class ID3Writer {
   _setIntegerFrame(name, value) {
     let integer;
-    if (name === 'TDAT'){
+    if (name === 'TDAT') {
       integer = String(parseInt(value, 10)).padStart(4, '0');
     } else {
       integer = parseInt(value, 10);

--- a/src/ID3Writer.mjs
+++ b/src/ID3Writer.mjs
@@ -18,7 +18,12 @@ import {
 
 export default class ID3Writer {
   _setIntegerFrame(name, value) {
-    const integer = parseInt(value, 10);
+    let integer;
+    if (name === 'TDAT'){
+      integer = String(parseInt(value, 10)).padStart(4, '0');
+    } else {
+      integer = parseInt(value, 10);
+    }
 
     this.frames.push({
       name,

--- a/test/integer/TDAT.mjs
+++ b/test/integer/TDAT.mjs
@@ -1,0 +1,31 @@
+import { deepStrictEqual } from 'assert';
+import { getEmptyBuffer, id3Header } from '../utils.mjs';
+import { encodeWindows1252 } from '../../src/encoder.mjs';
+import ID3Writer from '../../dist/browser-id3-writer.js';
+
+describe('TDAT', () => {
+  it('TDAT', () => {
+    const writer = new ID3Writer(getEmptyBuffer());
+    writer.padding = 0;
+    writer.setFrame('TDAT', '0212');
+    writer.addTag();
+    const actual = new Uint8Array(writer.arrayBuffer);
+    const expected = new Uint8Array([
+      ...id3Header,
+      0,
+      0,
+      0,
+      15, // tag size without header
+      ...encodeWindows1252('TDAT'),
+      0,
+      0,
+      0,
+      5, // frame size without header
+      0,
+      0, // flags
+      0, // encoding
+      ...encodeWindows1252('0212'),
+    ]);
+    deepStrictEqual(actual, expected);
+  });
+});


### PR DESCRIPTION
The ID3 tag TDAT must always be 4 character long
Added a test for that as well.

https://egoroof.github.io/browser-id3-writer/spec/#TDAT