### PR TITLE
Fix typos and add TypeScript declaration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,14 +346,14 @@ See [#42](https://github.com/egoroof/browser-id3-writer/issues/42).
 | 3    | Cover (front)                       |
 | 4    | Cover (back)                        |
 | 5    | Leaflet page                        |
-| 6    | Media (e.g. lable side of CD)       |
+| 6    | Media (e.g. label side of CD)       |
 | 7    | Lead artist/lead performer/soloist  |
 | 8    | Artist/performer                    |
 | 9    | Conductor                           |
 | 10   | Band/Orchestra                      |
 | 11   | Composer                            |
 | 12   | Lyricist/text writer                |
-| 13   | Recording Location                  |
+| 13   | Recording location                  |
 | 14   | During recording                    |
 | 15   | During performance                  |
 | 16   | Movie/video screen capture          |

--- a/browser-id3-writer.d.ts
+++ b/browser-id3-writer.d.ts
@@ -1,0 +1,242 @@
+declare module 'browser-id3-writer' {
+  export const enum SynchronizedLyricsType {
+    Other = 0,
+    Lyrics = 1,
+
+    /**
+     * Text transcription
+     */
+    TextTranscription = 2,
+
+    /**
+     * Movement/part name (e.g. "Adagio")
+     */
+    MovementPartName = 3,
+
+    /**
+     * Events (e.g. "Don Quijote enters the stage")
+     */
+    Events = 4,
+
+    /**
+     * Chord (e.g. "Bb F Fsus")
+     */
+    Chord = 5,
+
+    /**
+     * Trivia/'pop up' information
+     */
+    Trivia = 6,
+  }
+
+  export const enum SynchronizedLyricsTimestampFormat {
+    /**
+     * Absolute time, 32 bit sized, using MPEG frames as unit
+     */
+    Frames = 0x01,
+
+    /**
+     * Absolute time, 32 bit sized, using milliseconds as unit
+     */
+    Milliseconds = 0x02,
+  }
+
+  // id3.org uses hex values for these. I'm keeping them as hex for consistency
+  // with the documentation.
+  export const enum ImageType {
+    Other = 0x00,
+    /**
+     * 32x32 pixels 'file icon' (PNG only)
+     */
+    Icon = 0x01,
+
+    /**
+     * Other file icon
+     */
+    OtherIcon = 0x02,
+
+    /**
+     * Cover (front)
+     */
+    CoverFront = 0x03,
+
+    /**
+     * Cover (back)
+     */
+    CoverBack = 0x04,
+
+    /**
+     * Leaflet page
+     */
+    Leaflet = 0x05,
+
+    /**
+     * Media (e.g. label side of CD)
+     */
+    Media = 0x06,
+
+    /**
+     * Lead artist/lead performer/soloist
+     */
+    LeadArtist = 0x07,
+
+    /**
+     * Artist/performer
+     */
+    Artist = 0x08,
+
+    Conductor = 0x09,
+
+    /**
+     * Band/Orchestra
+     */
+    Band = 0x0a,
+
+    Composer = 0x0b,
+
+    /**
+     * Lyricist/text writer
+     */
+    Lyricist = 0x0c,
+
+    /**
+     * Recording location
+     */
+    RecordingLocation = 0x0d,
+
+    /**
+     * During recording
+     */
+    DuringRecording = 0x0e,
+
+    /**
+     * During performance
+     */
+    DuringPerformance = 0x0f,
+
+    /**
+     * Movie/video screen capture
+     */
+    MovieScreenCapture = 0x10,
+
+    /**
+     * A brightly coloured fish
+     */
+    BrightColouredFish = 0x11,
+
+    Illustration = 0x12,
+
+    /**
+     * Band/artist logotype
+     */
+    BandLogotype = 0x13,
+
+    /**
+     * Publisher/Studio logotype
+     */
+    PublisherLogotype = 0x14,
+  }
+
+  export class ID3Writer {
+    constructor(buffer: ArrayBufferLike);
+
+    setFrame(id: 'TBPM' | 'TLEN' | 'TYER', value: number): this;
+
+    setFrame(
+      id:
+        | 'TALB'
+        | 'TCOP'
+        | 'TDAT'
+        | 'TEXT'
+        | 'TIT1'
+        | 'TIT2'
+        | 'TIT3'
+        | 'TKEY'
+        | 'TLAN'
+        | 'TMED'
+        | 'TPE2'
+        | 'TPE3'
+        | 'TPE4'
+        | 'TPOS'
+        | 'TPUB'
+        | 'TRCK'
+        | 'TSRC',
+      value: string,
+    ): this;
+
+    setFrame(id: 'TCOM' | 'TCON' | 'TPE1', value: readonly string[]): this;
+
+    setFrame(
+      id: 'USLT',
+      value: {
+        readonly description: string;
+        readonly language?: string;
+        readonly lyrics: string;
+      },
+    ): this;
+
+    setFrame(
+      id: 'APIC',
+      value: {
+        readonly description: string;
+        readonly data: ArrayBufferLike;
+        readonly mimeType: string;
+        readonly type: ImageType;
+        readonly useUnicodeEncoding?: boolean;
+      },
+    ): this;
+
+    setFrame(
+      id: 'TXXX',
+      value: {
+        readonly description: string;
+        readonly value: string;
+      },
+    ): this;
+
+    setFrame(
+      id: 'WCOM' | 'WCOP' | 'WOAF' | 'WOAR' | 'WOAS' | 'WORS' | 'WPAY' | 'WPUB',
+      value: URL | string,
+    ): this;
+
+    setFrame(
+      id: 'COMM',
+      value: {
+        readonly language?: string;
+        readonly description: string;
+        readonly text: string;
+      },
+    ): this;
+
+    setFrame(
+      id: 'PRIV',
+      value: {
+        readonly id: string;
+        readonly data: ArrayBufferLike;
+      },
+    ): this;
+
+    setFrame(id: 'IPLS', value: readonly (readonly [string, string])[]): this;
+
+    setFrame(
+      id: 'SYLT',
+      value: {
+        readonly type: SynchronizedLyricsType;
+        readonly text: readonly (readonly [string, number])[];
+        readonly timestampFormat: SynchronizedLyricsTimestampFormat;
+        readonly language?: string;
+        readonly description?: string;
+      },
+    ): this;
+
+    removeTag(): void;
+
+    addTag(): ArrayBuffer;
+
+    getBlob(): Blob;
+
+    getURL(): URL;
+
+    revokeURL(): void;
+  }
+}

--- a/browser-id3-writer.d.ts
+++ b/browser-id3-writer.d.ts
@@ -1,32 +1,34 @@
+// Hexidecimal values used to maintain consistency with the ID3v2.3
+// documentation. Refer to /tools/id3v2.3.0.txt.
 declare module 'browser-id3-writer' {
   export const enum SynchronizedLyricsType {
-    Other = 0,
-    Lyrics = 1,
+    Other = 0x00,
+    Lyrics = 0x01,
 
     /**
      * Text transcription
      */
-    TextTranscription = 2,
+    TextTranscription = 0x02,
 
     /**
      * Movement/part name (e.g. "Adagio")
      */
-    MovementPartName = 3,
+    MovementPartName = 0x03,
 
     /**
      * Events (e.g. "Don Quijote enters the stage")
      */
-    Events = 4,
+    Events = 0x04,
 
     /**
      * Chord (e.g. "Bb F Fsus")
      */
-    Chord = 5,
+    Chord = 0x05,
 
     /**
      * Trivia/'pop up' information
      */
-    Trivia = 6,
+    Trivia = 0x06,
   }
 
   export const enum SynchronizedLyricsTimestampFormat {
@@ -41,8 +43,6 @@ declare module 'browser-id3-writer' {
     Milliseconds = 0x02,
   }
 
-  // id3.org uses hex values for these. I'm keeping them as hex for consistency
-  // with the documentation.
   export const enum ImageType {
     Other = 0x00,
     /**

--- a/browser-id3-writer.d.ts
+++ b/browser-id3-writer.d.ts
@@ -195,7 +195,7 @@ declare module 'browser-id3-writer' {
 
     setFrame(
       id: 'WCOM' | 'WCOP' | 'WOAF' | 'WOAR' | 'WOAS' | 'WORS' | 'WPAY' | 'WPUB',
-      value: URL | string,
+      value: string,
     ): this;
 
     setFrame(

--- a/browser-id3-writer.d.ts
+++ b/browser-id3-writer.d.ts
@@ -234,7 +234,7 @@ declare module 'browser-id3-writer' {
 
     getBlob(): Blob;
 
-    getURL(): URL;
+    getURL(): string;
 
     revokeURL(): void;
   }

--- a/browser-id3-writer.d.ts
+++ b/browser-id3-writer.d.ts
@@ -180,7 +180,6 @@ declare module 'browser-id3-writer' {
       value: {
         readonly description: string;
         readonly data: ArrayBufferLike;
-        readonly mimeType: string;
         readonly type: ImageType;
         readonly useUnicodeEncoding?: boolean;
       },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.0.0",
   "description": "JavaScript library for writing ID3 tag to MP3 files in browsers and Node.js",
   "main": "dist/browser-id3-writer.mjs",
+  "types": "./browser-id3-writer.d.ts",
   "scripts": {
     "lint": "eslint src tools test --ext js,mjs",
     "build": "npm run build:bundle && npm run build:compress && node tools/distSize.mjs",
@@ -34,6 +35,7 @@
   "files": [
     "LICENSE.md",
     "README.md",
+    "browser-id3-writer.d.ts",
     "dist/browser-id3-writer.mjs"
   ],
   "license": "MIT",


### PR DESCRIPTION
This addresses #78 

Types being picked up by VSCode:

![image](https://github.com/egoroof/browser-id3-writer/assets/270430/d7997109-8eb9-49d5-909b-07c57f3075dd)

![image](https://github.com/egoroof/browser-id3-writer/assets/270430/a2bc03b6-56e6-444d-9a07-5fff504b182e)

Screenshot showing the results of passing through the TypeScript compiler; note ImageType.CoverFront is correctly replaced.

![image](https://github.com/egoroof/browser-id3-writer/assets/270430/4b0083eb-688b-44b6-8af9-956d6a54a0b0)
