### PR TITLE
add iTunes compilation flag

### DIFF
--- a/browser-id3-writer.d.ts
+++ b/browser-id3-writer.d.ts
@@ -146,6 +146,7 @@ declare module 'browser-id3-writer' {
       id:
         | 'TALB'
         | 'TCOP'
+        | 'TCMP'
         | 'TDAT'
         | 'TEXT'
         | 'TIT1'

--- a/src/ID3Writer.mjs
+++ b/src/ID3Writer.mjs
@@ -209,6 +209,7 @@ export class ID3Writer {
       case 'TKEY': // musical key in which the sound starts
       case 'TEXT': // lyricist / text writer
       case 'TDAT': // album release date expressed as DDMM
+      case 'TCMP': // compilation flag ("1" stored as a string)
       case 'TSRC': {
         // isrc
         this._setStringFrame(frameName, frameValue);


### PR DESCRIPTION
Fixes #91 

Testing:
repackaged deemix with the patched library, it set the flag as expected and didn't error out.